### PR TITLE
Implement Tables.schema for JSONTables.Table 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,29 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-
-sudo: false
 
 os:
   - linux
   - osx
   - windows
 
-arch:
-  - x64
-  - x86
-
 julia:
   - 1.0
-  - 1.3
+  - 1
   - nightly
 
-env:
-  - JULIA_PROJECT="@."
+branches:
+  only:
+  - master
+  - gh-pages # For building documentation
+  - /^testing-.*$/ # testing branches
+  - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 
-matrix:
-  exclude:
-    - os: osx
-      arch: x86
+jobs:
   allow_failures:
-  - julia: nightly
+    - julia: nightly
 
 notifications:
   email: false
 
 after_success:
-   - julia -e 'ENV["TRAVIS_JULIA_VERSION"] == "1.3" && ENV["TRAVIS_OS_NAME"] != "linux" && exit(); using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,4 +65,20 @@ text = """{
 }"""
 @test_throws ArgumentError JSONTables.jsontable(text)
 
+nonhomogenous = """
+[
+    {"a": 1, "b": 2, "c": 3},
+    {"b": 4, "c": null, "d": 5},
+    {"a": 6, "d": 7},
+    {"a": 8, "b": 9, "c": 10, "d": null},
+    {"d": 11, "c": 10, "b": 9, "a": 8}
+]
+"""
+
+jt = JSONTables.jsontable(nonhomogenous)
+@test Tables.schema(jt).names == (:a, :b, :c, :d)
+ct = Tables.columntable(jt)
+@test isequal(ct.a, [1, missing, 6, 8, 8])
+@test isequal(ct.d, [missing, 5, 7, missing, 11])
+
 end


### PR DESCRIPTION
Fixes #17. This PR updates the `jsontable` constructor function that
returns a `JSONTables.Table` object. It now does stricter checks that
the incoming object or array is actually a table (strict object of
arrays or array of objects); it also checks the names and types that
will be expected, with particular consideration for the array of
objects, where the objects may not all have the same "schema". We do a
pass over the array of objects, "union"-ing the columns from across all
rows, along with the value types. This obviously adds a performance hit
for initial table construction, but ultimately leads to a much more
predictable user experience. If the cost is indeed too prohibitive, we
can address the potential of adding a fast-path constructor later on,
which shouldn't be hard or disruptive.