### PR TITLE
jsontable(x::AbstractVector{<:JSON3.Object})

### DIFF
--- a/src/JSONTables.jl
+++ b/src/JSONTables.jl
@@ -31,11 +31,11 @@ function jsontable(x::JSON3.Object)
     return Table{true, typeof(x)}(names, types, x)
 end
 
-jsontable(x::JSON3.Array) = throw(ArgumentError("input `JSON3.Array` must only have `JSON3.Object` elements to be considered a table"))
+# jsontable(x::JSON3.Array) = throw(ArgumentError("input `JSON3.Array` must only have `JSON3.Object` elements to be considered a table"))
 missT(::Type{Nothing}) = Missing
 missT(::Type{T}) where {T} = T
 
-function jsontable(x::JSON3.Array{JSON3.Object})
+function jsontable(x::AbstractVector{<:JSON3.Object})
     names = Symbol[]
     seen = Set{Symbol}()
     types = Dict{Symbol, Type}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,4 +92,10 @@ jt = JSONTables.jsontable(new_field_in_last_row)
 ct = Tables.columntable(jt)
 @test isequal(ct.c, [missing, 8])
 
+# jsontable(::Vector{JSON3.Object}) test
+jstrs = JSON3.write.([Dict("a"=>rand(), "b"=>-rand()) for _ in 1:50])
+js = JSON3.read.(jstrs)
+jt = jsontable(js)
+@test jt isa JSONTables.Table
+
 end


### PR DESCRIPTION
@quinnj 

This PR making me realize I'm bad at type parameters, I think we still want the `jsontable(x::JSON3.Array)` dispatch that I commented out. 

Should I make it `jsontable(x::JSON3.Array{Any})` or something?

Thanks