### PR TITLE
Pass kwargs through to JSON3.read

### DIFF
--- a/src/JSONTables.jl
+++ b/src/JSONTables.jl
@@ -12,7 +12,7 @@ struct Table{columnar, T}
     source::T
 end
 
-jsontable(source) = jsontable(JSON3.read(source))
+jsontable(source; kwargs...) = jsontable(JSON3.read(source; kwargs...))
 
 misselT(::Type{T}) where {T} = T
 misselT(::Type{Union{Nothing, T}}) where {T} = Union{Missing, T}


### PR DESCRIPTION
This change allows passing keyword arguments from `jsontable` to `JSON3.read`. This is useful, for example, if the JSON is in the form of `jsonlines` rather than a single JSON object.